### PR TITLE
Allow rubocop to be run via rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,8 @@
 require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
-task default: :spec
+task default: %w[spec rubocop]
+
+RuboCop::RakeTask.new


### PR DESCRIPTION
And make the default task run both specs and rubocop